### PR TITLE
updates turf meta

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "multipolygon"
   ],
   "dependencies": {
-    "@turf/meta": "^3.7.5",
+    "@turf/meta": "^4.7.1",
     "geojson-flatten": "^0.2.1",
     "geojson-linestring-dissolve": "0.0.1",
     "topojson-client": "^3.0.0",


### PR DESCRIPTION
Updates dependency on `@turf/meta`  from version `^3` to `^4`.

Having this module depend of version 3 creates duplicate versions of `@turf/meta` in the `node_modules` folder.

If you accept this PR, please do tag it and publish to npm so I can update this dependency on my projects :fireworks: 